### PR TITLE
Fix WebApp log shipping

### DIFF
--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -42,11 +42,14 @@ jobs:
       CPANEL_API_URL: ((secrets.cpanel-api-url))
       CPANEL_API_USER: ((secrets.cpanel-api-user))
 
+  - get: config-repo
+
   - put: webapp-helm-release
     params:
       chart: mojanalytics/webapp
       values:
       - webapp-auth0-client/credentials.yaml
+      - helm-config/chart-env-config/alpha/webapp.yml
       - deploy-params/overrides.yaml
       override_values:
       - { key: WebApp.Name, value: ((app-name)) }
@@ -58,6 +61,12 @@ jobs:
       - { key: CookieSecret, value: ((secrets.cookie-secret)) }
 
 resources:
+- name: config-repo
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/analytics-platform-config.git
+    git_crypt_key: ((secrets.gitcrypt-symmetric-key))
+
 - name: common-tasks
   type: git
   source:


### PR DESCRIPTION
Environment variable values for fluentd-elasticsearch containers are empty for webapps
deployed in the last 3-4 months.
This adds configuration values/secrets to the webapp helm release which
should allow the fluentd-elasticsearch container to connect to
elasticsearch.