### PR TITLE
Allow webhooks and reduce polling frequency on pipelines

### DIFF
--- a/resource/airflow_dag_pipeline.yaml
+++ b/resource/airflow_dag_pipeline.yaml
@@ -57,6 +57,8 @@ resources:
 
 - name: release
   type: github-release
+  webhook_token: ((secrets.github-webhook-token))
+  check_every: 24h
   source:
     owner: ((github-org))
     repository: ((github-repo))

--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -65,6 +65,8 @@ resources:
 
 - name: release
   type: github-release
+  webhook_token: ((secrets.github-webhook-token))
+  check_every: 24h
   source:
     owner: ((github-org))
     repository: ((github-repo))


### PR DESCRIPTION
This commit changes the default polling period for the github release resource
from 1 minute to 24 hours. The reason we can do this is the new webhook
dispatcher. The dispatcher will trigger a 'check' on this resource when we
receive a notification from a github org hook telling us there has been a new
release.

Existing pipelines have been updated in-place but this change is required so new
pipelines also get these changes.

Once this is merged, a new release will need to be made and the [org scanner pipeline](https://github.com/ministryofjustice/analytics-platform-helm-charts/blob/c984d4e4ee3a0a0844f90bdbf293cca571acc2d0/charts/concourse-org-pipeline/files/pipeline.yaml#L27) will have to be updated to use this new release in [dev](https://github.com/ministryofjustice/analytics-platform-config/blob/3c1ce93de426c51cae8bb0cf58337f40b655add0/chart-env-config/dev/concourse-org-pipeline.yaml#L59) and [alpha](https://github.com/ministryofjustice/analytics-platform-config/blob/6d98ba132dfc0b34fbd5f48c41d9a466c010cab3/chart-env-config/alpha/concourse-org-pipeline.yaml#L59)