### PR TITLE
BUGFIX: Remove duplicate key in pipeline

### DIFF
--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -80,7 +80,6 @@ resources:
     owner: ((github-org))
     repository: ((github-repo))
     access_token: ((secrets.github-access-token))
-  check_every: 2m
 
 - name: webapp-auth0-client
   type: auth0-client


### PR DESCRIPTION
This removes the duplicate `check_every` key in the webapp pipeline. It should
only be there once with a value of 24h