### PR TITLE
Adds lookup pipeline to build lookup tables

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 python-dateutil
 pyyaml
+python-fly

--- a/resource/lookup_pipeline.yaml
+++ b/resource/lookup_pipeline.yaml
@@ -22,6 +22,8 @@ jobs:
         source:
           repository: quay.io/mojanalytics/lookup-tables-etl
           tag: v0.0.1
+      inputs:
+        - name: lookup-source
       run:
         path: python
         args:

--- a/resource/lookup_pipeline.yaml
+++ b/resource/lookup_pipeline.yaml
@@ -14,25 +14,6 @@ jobs:
     file: common-tasks/extract-release-tarball.yaml
     output_mapping: {extracted: lookup-source}
 
-  - get: iam-policy
-
-  - task: create-iam-role-name
-      file: common-tasks/put-iam-role.yaml
-
-      output_mapping: {output: aws}
-      input_mapping:
-        source: iam-policy
-
-      params:
-        ORG_NAME: ((github-org))
-        REPO_NAME: ((github-repo))
-        AWS_ACCESS_KEY_ID: ((secrets.role-putter-access-key-id))
-        AWS_SECRET_ACCESS_KEY: ((secrets.role-putter-secret-access-key))
-        AWS_NODES_ROLE_ARN: ((secrets.nodes-role-arn))
-        APP_NAME: ((app-name))
-
-  - get: config-repo
-
   - task: run-lookup-etl
     config:
       platform: linux
@@ -46,25 +27,14 @@ jobs:
         args:
           - etl/run.py
       params:
-        AWS_ACCESS_KEY_ID: ((lookup-access-key-id))
-        AWS_SECRET_ACCESS_KEY: ((lookup-secret-access-key))
+        AWS_ACCESS_KEY_ID: ((secrets.lookup-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((secrets.lookup-secret-access-key))
 
 resources:
-  - name: config-repo
-    type: git
-    source:
-      uri: https://github.com/ministryofjustice/analytics-platform-config.git
-      git_crypt_key: ((secrets.gitcrypt-symmetric-key))
-
 - name: common-tasks
   type: git
   source:
     uri: https://github.com/ministryofjustice/analytics-platform-common-concourse-tasks.git
-
-- name: iam-policy
-  type: git
-  source:
-    uri: https://github.com/moj-analytical-services/docker-lookup-tables.git
 
 - name: release
   type: github-release

--- a/resource/lookup_pipeline.yaml
+++ b/resource/lookup_pipeline.yaml
@@ -1,0 +1,76 @@
+---
+jobs:
+- name: deploy
+  plan:
+
+  - get: release
+    trigger: true
+    params:
+      include_source_tarball: true
+
+  - get: common-tasks
+
+  - task: lookup-source
+    file: common-tasks/extract-release-tarball.yaml
+    output_mapping: {extracted: lookup-source}
+
+  - get: iam-policy
+
+  - task: create-iam-role-name
+      file: common-tasks/put-iam-role.yaml
+
+      output_mapping: {output: aws}
+      input_mapping:
+        source: iam-policy
+
+      params:
+        ORG_NAME: ((github-org))
+        REPO_NAME: ((github-repo))
+        AWS_ACCESS_KEY_ID: ((secrets.role-putter-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((secrets.role-putter-secret-access-key))
+        AWS_NODES_ROLE_ARN: ((secrets.nodes-role-arn))
+        APP_NAME: ((app-name))
+
+  - get: config-repo
+
+  - task: run-lookup-etl
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: quay.io/mojanalytics/lookup-tables-etl
+          tag: v0.0.1
+      run:
+        path: python
+        args:
+          - etl/run.py
+      params:
+        AWS_ACCESS_KEY_ID: ((lookup-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((lookup-secret-access-key))
+
+resources:
+  - name: config-repo
+    type: git
+    source:
+      uri: https://github.com/ministryofjustice/analytics-platform-config.git
+      git_crypt_key: ((secrets.gitcrypt-symmetric-key))
+
+- name: common-tasks
+  type: git
+  source:
+    uri: https://github.com/ministryofjustice/analytics-platform-common-concourse-tasks.git
+
+- name: iam-policy
+  type: git
+  source:
+    uri: https://github.com/moj-analytical-services/docker-lookup-tables.git
+
+- name: release
+  type: github-release
+  webhook_token: ((secrets.github-webhook-token))
+  check_every: 24h
+  source:
+    owner: ((github-org))
+    repository: ((github-repo))
+    access_token: ((secrets.github-access-token))

--- a/resource/out
+++ b/resource/out
@@ -5,8 +5,6 @@ import json
 
 from fly import Fly
 from moj_analytics.concourse import Resource
-import requests
-import yaml
 
 from common import get_all, get_org, github_api_request, pushed_at
 
@@ -71,19 +69,6 @@ def create_pipelines(src_dir, source={}, params={}):
     timestamps = sorted(set(map(pushed_at, repos)))
 
     return {'version': {'ref': str(timestamps[-1])}}
-
-
-def get_pipelines(concourse_url, team_name, **kwargs):
-    with open('/root/.flyrc') as f:
-        fly_config = yaml.load(f.read())
-    token = fly_config['targets']['default']['token']['value']
-
-    url = f'{concourse_url}/api/v1/teams/{team_name}/pipelines'
-    headers = {
-        'Cookie': f'ATC-Authorization="Bearer {token}"',
-    }
-    pipelines = requests.get(url, headers=headers).json()
-    return [p['name'] for p in pipelines]
 
 
 def buildfile_exists(repo, **kwargs):

--- a/resource/out
+++ b/resource/out
@@ -1,18 +1,15 @@
 #!/usr/bin/env python
 
-import os
 import re
-import subprocess
 import json
 
+from fly import Fly
 from moj_analytics.concourse import Resource
 import requests
 import yaml
 
 from common import get_all, get_org, github_api_request, pushed_at
 
-
-fly = '/usr/local/bin/fly'
 
 INVALID_CHARS = re.compile(r'[^-a-z0-9]')
 SURROUNDING_HYPHENS = re.compile(r'^-*|-*$')
@@ -27,11 +24,18 @@ class ansi:
 @Resource
 def create_pipelines(src_dir, source={}, params={}):
     print('Logging in to Concourse')
-    get_fly(**source)
-    fly_login(**source)
+    fly = Fly(
+        concourse_url=source.get('concourse_url')
+    )
+    fly.get_fly()
+    fly.login(
+        username=source.get('username'),
+        password=source.get('password'),
+        team_name=source.get('team_name')
+    )
 
     print('Fetching existing pipelines', flush=True)
-    pipelines = get_pipelines(**source)
+    pipelines = [p['name'] for p in fly.get_json('pipelines')]
     print(f'Found {len(pipelines)} pipelines', flush=True)
 
     print(f'Fetching {source["name"]} org', flush=True)
@@ -57,7 +61,7 @@ def create_pipelines(src_dir, source={}, params={}):
 
             pipeline_type = buildfile_type(repo, **source)
 
-            fly_set_pipeline(repo, pipeline_type=pipeline_type, **source)
+            fly_set_pipeline(fly, repo, pipeline_type=pipeline_type, **source)
 
         else:
             print(
@@ -101,44 +105,16 @@ def buildfile_type(repo, **kwargs):
     return deploy_type
 
 
-def get_fly(concourse_url, **kwargs):
-    url = f'{concourse_url}/api/v1/cli?arch=amd64&platform=linux'
-    response = requests.get(url, stream=True)
-    if response.status_code == 200:
-        with open(fly, 'wb') as f:
-            for chunk in response:
-                f.write(chunk)
-        os.chmod(fly, 0o755)  # make executable
-
-
-def fly_login(concourse_url, username, password, team_name, **source):
-    subprocess.run(
-        [
-            fly, '-t', 'default', 'login',
-            '-c', concourse_url,
-            '-u', username,
-            '-p', password,
-            '-n', team_name
-        ],
-        stdout=subprocess.PIPE,
-        check=True)
-
-
-def fly_set_pipeline(repo, team_name, pipeline_type='webapp', **kwargs):
+def fly_set_pipeline(fly, repo, team_name, pipeline_type='webapp', **kwargs):
     app_name = normalize(repo['name'])
-    subprocess.run(
-        [
-            fly, '-t', 'default', 'set-pipeline',
-            '-p', repo["name"],
-            '-c', f'/opt/resource/{pipeline_type}_pipeline.yaml',
-            '-v', f'app-name={app_name}',
-            '-v', f'github-org={kwargs["name"]}',
-            '-v', f'github-repo={repo["name"]}',
-            '-n'
-
-        ],
-        stdout=subprocess.PIPE,
-        check=True)
+    fly.run(
+        'set-pipeline',
+        '-p', repo["name"],
+        '-c', f'/opt/resource/{pipeline_type}_pipeline.yaml',
+        '-v', f'app-name={app_name}',
+        '-v', f'github-org={kwargs["name"]}',
+        '-v', f'github-repo={repo["name"]}',
+        '-n')
 
 
 def normalize(name):


### PR DESCRIPTION
Merging this will add a `lookup_pipeline.yaml` file which will run a pipeline from a docker image built from `quay.io/mojanalytics/lookup-tables-etl`. This will copy data from a `lookup_` prefixed repo in to the lookup tables s3 bucket.

It also removes the `get_pipelines` call to the concourse web api and replaces it with a call to the concourse fly executable.

It relies on creating a lookup table IAM role in terraform.