### PR TITLE
Update webapp pipeline to use v2.0.0 auth0 client resource

### DIFF
--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -117,7 +117,7 @@ resource_types:
   type: docker-image
   source:
     repository: quay.io/mojanalytics/concourse-auth0-resource
-    tag: v0.1.0
+    tag: v2.0.0
 
 - name: ecr-repo
   type: docker-image


### PR DESCRIPTION
This updates the auth0 client resource to version 2.0.0 which supports the
`connections` property in deploy.json (v1.1.0)

depends on: https://github.com/ministryofjustice/analytics-platform-concourse-auth0-client-resource/pull/3/files