### PR TITLE
Switch from Github v3 API to Github v4 GraphQL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 venv
+*.egg-info/
+*.iml
+**/__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM python:3.6.5-alpine3.4
+FROM python:3-alpine
 
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
-COPY moj_analytics /usr/local/lib/python3.6/site-packages/moj_analytics
+RUN pip install -U pip && pip install --no-cache-dir -r requirements.txt
+COPY moj_analytics /tmp/moj_analytics
+RUN  pip install /tmp/moj_analytics && rm -rf /tmp/moj_analytics
 COPY resource /opt/resource
 RUN chmod +x /opt/resource/*

--- a/moj_analytics/moj_analytics/concourse.py
+++ b/moj_analytics/moj_analytics/concourse.py
@@ -5,14 +5,13 @@ import sys
 
 
 class Resource(object):
-
     def __init__(self, fn):
         self.fn = fn
 
         self.action = os.path.basename(sys.argv[0]).lower()
 
         self.args = []
-        if self.action in ('in', 'out'):
+        if self.action in ("in", "out"):
             self.args.append(sys.argv[1])
 
         self.kwargs = json.loads(sys.stdin.read())

--- a/moj_analytics/setup.py
+++ b/moj_analytics/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup, find_packages
+
+setup(name="moj_analytics", version="0.1dev", license="MIT", packages=find_packages())

--- a/resource/check
+++ b/resource/check
@@ -2,25 +2,25 @@
 
 from moj_analytics.concourse import Resource
 
-from common import get_all, get_org, pushed_at
+from common import get_org, pushed_at, get_all_repos
 
 
 @Resource
 def get_versions(source={}, version=None):
     print(f'Fetching {source["name"]} org', flush=True)
-    org = get_org(**source)
 
-    print('Fetching org repos', flush=True)
-    repos = get_all(org['repos_url'], **source)
+    print("Fetching org repos", flush=True)
+    repos = get_all_repos(source)
 
+    print(f"{len(repos)} repos found", flush=True)
     timestamps = sorted(set(map(pushed_at, repos)))
 
-    if version is not None and version.get('ref') != 'none':
-        version = int(version['ref'])
+    if version is not None and version.get("ref") != "none":
+        version = int(version["ref"])
         timestamps = filter(lambda ts: ts >= version, timestamps)
 
-    return [{'ref': str(ts)} for ts in timestamps]
+    return [{"ref": str(ts)} for ts in timestamps]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     get_versions()

--- a/resource/in
+++ b/resource/in
@@ -1,31 +1,29 @@
 #!/usr/bin/env python
-
 from os.path import join
 import json
 
 from moj_analytics.concourse import Resource
-
-from common import get_all, get_org, pushed_at
+from common import get_org, pushed_at, get_all_repos
 
 
 @Resource
 def get_org_repos(dest_dir, source={}, version=None, params={}):
     print(f'Fetching {source["name"]} org', flush=True)
     org = get_org(**source)
-    with open(join(dest_dir, 'org'), 'w') as org_file:
+    with open(join(dest_dir, "org"), "w") as org_file:
         json.dump(org, org_file)
 
-    print('Fetching org repos', flush=True)
-    repos = get_all(org['repos_url'], **source)
-    with open(join(dest_dir, 'repos'), 'w') as repos_file:
-        json.dump(repos, repos_file)
+    print("Fetching org repos", flush=True)
+    repo_list = get_all_repos(source)
+    with open(join(dest_dir, "repos"), "w") as repos_file:
+        json.dump(repo_list, repos_file)
 
-    print(f'{len(repos)} repos found', flush=True)
+    print(f"{len(repo_list)} repos found", flush=True)
 
-    timestamps = sorted(set(map(pushed_at, repos)))
+    timestamps = sorted(set(map(pushed_at, repo_list)))
 
-    return {'version': {'ref': str(timestamps[-1])}}
+    return {"version": {"ref": str(timestamps[-1])}}
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     get_org_repos()

--- a/resource/out
+++ b/resource/out
@@ -6,111 +6,108 @@ import json
 from fly import Fly
 from moj_analytics.concourse import Resource
 
-from common import get_all, get_org, github_api_request, pushed_at
+from common import pushed_at, get_all_repos
 
-
-INVALID_CHARS = re.compile(r'[^-a-z0-9]')
-SURROUNDING_HYPHENS = re.compile(r'^-*|-*$')
+INVALID_CHARS = re.compile(r"[^-a-z0-9]")
+SURROUNDING_HYPHENS = re.compile(r"^-*|-*$")
 
 
 class ansi:
-    green = '\x1b[92m'
-    grey = '\x1b[90m'
-    reset = '\x1b[0m'
+    green = "\x1b[92m"
+    grey = "\x1b[90m"
+    reset = "\x1b[0m"
 
 
 @Resource
 def create_pipelines(src_dir, source={}, params={}):
-    print('Logging in to Concourse')
-    fly = Fly(
-        concourse_url=source.get('concourse_url')
-    )
+    print("Logging in to Concourse")
+    fly = Fly(concourse_url=source.get("concourse_url"))
     fly.get_fly()
     fly.login(
-        username=source.get('username'),
-        password=source.get('password'),
-        team_name=source.get('team_name')
+        username=source.get("username"),
+        password=source.get("password"),
+        team_name=source.get("team_name"),
     )
 
-    print('Fetching existing pipelines', flush=True)
+    print("Fetching existing pipelines", flush=True)
     pipelines = get_pipelines(fly)
-    print(f'Found {len(pipelines)} pipelines', flush=True)
+    print(f"Found {len(pipelines)} pipelines", flush=True)
 
     print(f'Fetching {source["name"]} org', flush=True)
-    org = get_org(**source)
 
-    print('Fetching org repos', flush=True)
-    repos = get_all(org['repos_url'], **source)
+    print("Fetching org repos", flush=True)
+    repos = get_all_repos(source)
 
     for repo in repos:
         if buildfile_exists(repo, **source):
-            if repo['name'] in pipelines:
-                print(
-                    f'Pipeline exists for {repo["name"]}',
-                    flush=True)
+            if repo["name"] in pipelines:
+                print(f'Pipeline exists for {repo["name"]}', flush=True)
             else:
                 print(
                     (
-                        f'{ansi.green}Creating pipeline for '
+                        f"{ansi.green}Creating pipeline for "
                         f'{repo["name"]}{ansi.reset}'
                     ),
-                    flush=True)
+                    flush=True,
+                )
 
             pipeline_type = buildfile_type(repo, **source)
 
             fly_set_pipeline(fly, repo, pipeline_type=pipeline_type, **source)
 
         else:
-            print(
-                f'{ansi.grey}No buildfile for {repo["name"]}{ansi.reset}',
-                flush=True)
+            print(f'{ansi.grey}No buildfile for {repo["name"]}{ansi.reset}', flush=True)
 
     timestamps = sorted(set(map(pushed_at, repos)))
 
-    return {'version': {'ref': str(timestamps[-1])}}
+    return {"version": {"ref": str(timestamps[-1])}}
 
 
 def get_pipelines(fly):
-    return [str(p).split(' ')[0] for p in
-            fly.run('pipelines').stdout.decode('utf-8').splitlines()]
+    return [
+        str(p).split(" ")[0]
+        for p in fly.run("pipelines").stdout.decode("utf-8").splitlines()
+    ]
 
 
 def buildfile_exists(repo, **kwargs):
-    url = repo['contents_url'].replace('{+path}', 'deploy.json')
-    return github_api_request(url, **kwargs).status_code != 404
+    return repo["deploy"] != None
 
 
 def buildfile_type(repo, **kwargs):
-    url = repo['contents_url'].replace('{+path}', 'deploy.json')
-    metadata = github_api_request(url, **kwargs).json()
-    download_url = metadata['download_url']
-    deploy_type = 'webapp'
+    deploy_type = "webapp"
     try:
-        deploy_file = github_api_request(download_url, **kwargs).json()
-        deploy_type = deploy_file.get('type', 'webapp')
+        deploy_file = json.loads(repo["deploy"]["body"])
+        deploy_type = deploy_file.get("type", "webapp")
     except json.decoder.JSONDecodeError:  # handle malformed deploy.json
         # if json is malformed just assume it's a webapp deploy
         pass
     return deploy_type
 
 
-def fly_set_pipeline(fly, repo, team_name, pipeline_type='webapp', **kwargs):
-    app_name = normalize(repo['name'])
+def fly_set_pipeline(fly, repo, team_name, pipeline_type="webapp", **kwargs):
+    app_name = normalize(repo["name"])
     fly.run(
-        'set-pipeline',
-        '-p', repo["name"],
-        '-c', f'/opt/resource/{pipeline_type}_pipeline.yaml',
-        '-v', f'app-name={app_name}',
-        '-v', f'github-org={kwargs["name"]}',
-        '-v', f'github-repo={repo["name"]}',
-        '-n')
+        "set-pipeline",
+        "-p",
+        repo["name"],
+        "-c",
+        f"/opt/resource/{pipeline_type}_pipeline.yaml",
+        "-v",
+        f"app-name={app_name}",
+        "-v",
+        f'github-org={kwargs["name"]}',
+        "-v",
+        f'github-repo={repo["name"]}',
+        "-n",
+    )
 
 
 def normalize(name):
     name = name.lower()
-    name = SURROUNDING_HYPHENS.sub('', INVALID_CHARS.sub('-', name))
+    name = SURROUNDING_HYPHENS.sub("", INVALID_CHARS.sub("-", name))
     return name[:50]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     create_pipelines()

--- a/resource/queries.py
+++ b/resource/queries.py
@@ -1,0 +1,29 @@
+
+def repos(org, after="null"):
+  return """
+{
+  organization(login: "%(org)s") {
+    name
+    repositories(first: 100, after: %(after)s) {
+      totalCount,
+      pageInfo {
+        hasNextPage,
+        endCursor
+      },
+      totalDiskUsage
+      edges {
+        cursor,
+        node {
+          name,
+          pushedAt,
+          deploy: object(expression: "master:deploy.json") {
+            ... on Blob {
+              body: text
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""" % {'org': org, 'after': after}


### PR DESCRIPTION
This changes how we make requests to the github api. By using the graphql based
API we are reducing our api calls by 90%.

Also ran python black on the files as the formatting was a bit weird

v0.9.0 of this task takes ~ [7m 21s](https://concourse.services.alpha.mojanalytics.xyz/teams/admin/pipelines/create-webapp-pipelines/jobs/update-org-pipelines/builds/2186)
this PR takes ~[2m 9s](https://concourse.services.alpha.mojanalytics.xyz/teams/admin/pipelines/create-webapp-pipelines/jobs/update-org-pipelines/builds/2187)

The graphql code is a bit clunky but I wanted to make this change as minimal as possible as we don't have a dev environment to test on :face_with_head_bandage: 

