### PR TITLE
Add param for IP_TURING

### DIFF
--- a/resource/airflow_dag_pipeline.yaml
+++ b/resource/airflow_dag_pipeline.yaml
@@ -28,6 +28,7 @@ jobs:
       IPS_DOM1: ((secrets.ip-dom1))
       IPS_QUANTUM: ((secrets.ip-quantum))
       IPS_102PF_WIFI: ((secrets.ip-102pf))
+      IPS_TURING: ((secrets.ip-turing))
 
   - put: dag-docker-repo
 

--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -23,6 +23,7 @@ jobs:
         IPS_DIGITAL: ((secrets.ip-digital))
         IPS_QUANTUM: ((secrets.ip-quantum))
         IPS_102PF_WIFI: ((secrets.ip-102pf))
+        IPS_TURING: ((secrets.ip-turing))
 
     - put: webapp-docker-repo
 


### PR DESCRIPTION
The param will hold the CIDR for the IP of the Alan Turing Institute for whitelisting

https://trello.com/c/YswsWozF/295-add-ip-for-turing-institute#