### PR TITLE
Make sure Docker images have the right tag

### DIFF
--- a/resource/docker_build_pipeline.yaml
+++ b/resource/docker_build_pipeline.yaml
@@ -66,7 +66,6 @@ jobs:
           args:
             - -ec
             - |
-              jq -r '.[2] | .value' $(pwd)/pull-request/.git/resource/metadata.json > $(pwd)/pull-request/tag
               jq -n "{
                 source: {
                   repository: \"$(cat docker-repo/uri)\",
@@ -75,7 +74,7 @@ jobs:
                 },
                 params: {
                   build: \"$(pwd)/pull-request\",
-                  tag: \"$(pwd)/pull-request/tag\"
+                  tag: \"$(pwd)/pull-request/.git/resource/head_name\"
                 }
               }" | /opt/resource/out docker-image
       on_failure:


### PR DESCRIPTION
The build-docker-image task in docker_build_pipeline.yaml gets its tag from the resource's metadata.json. It indexes the metadata and brings back the third item. 

However, [the order of this metadata has changed](https://github.com/telia-oss/github-pr-resource/commit/735beaf89ec16b8e3819bc6c7f52028b9b95cdff), which will lead to errors when this task runs. To avoid that, this pull request changes the task to get its tag from the resource's headname rather than indexing the metadata file. 

We've seen these problems in airflow_dag_pipeline.yaml, and [fixed them in the same way](https://github.com/ministryofjustice/analytics-platform-concourse-github-org-resource/pull/40). 

It doesn't look like this yaml is used as often, but we might as well fix it pre-emptively just in case. 