### PR TITLE
Improvements to Auth0 Resource

### DIFF
--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -142,7 +142,7 @@ resource_types:
   type: docker-image
   source:
     repository: quay.io/mojanalytics/concourse-auth0-resource
-    tag: v2.0.0
+    tag: v2.0.1
 
 - name: ecr-repo
   type: docker-image


### PR DESCRIPTION
Using [concourse-auth0-resource `v2.0.1`] which handles better non-2xx
responses from Auth0 API and also adds useful logging.

[concourse-auth0-resource `v2.0.1`]: https://github.com/ministryofjustice/analytics-platform-concourse-auth0-client-resource/releases/tag/v2.0.1