### PR TITLE
Fix Auth0's `504  Gateway Timeout`

### DIFF
--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -142,7 +142,7 @@ resource_types:
   type: docker-image
   source:
     repository: quay.io/mojanalytics/concourse-auth0-resource
-    tag: v2.0.1
+    tag: v2.0.2
 
 - name: ecr-repo
   type: docker-image


### PR DESCRIPTION
Use Auth0 resource [v2.0.2] which doesn't send a body for GET requests.
This seem to cause this strange error on Auth0 end.

Part of ticket: https://trello.com/c/I2GozO5D

[v2.0.2]: https://github.com/ministryofjustice/analytics-platform-concourse-auth0-client-resource/releases/tag/v2.0.2