### PR TITLE
update-pipelines-resource-types.py: handle no resource types

### DIFF
--- a/update-pipelines-resource-types.py
+++ b/update-pipelines-resource-types.py
@@ -85,6 +85,9 @@ class Concourse():
 
 
 def update_resource_tag(pipeline, resource_name, new_tag):
+    if not pipeline.get("resource_types"):
+        return
+
     for t in pipeline.get("resource_types", []):
         if t["name"] == resource_name:
             t["source"]["tag"] = new_tag


### PR DESCRIPTION
When running this on `alpha`, update of one of the pipelines failed.
Reason being this `aws-whoami` pipeline has a `resource_types` field
set to `null`/`None`.

The script was handling the case when this `resource_types` field
was not there but not when it was `null`.

I've tweaked the script to check if `resource_types` is truthy
before trying to manipulate its definition.