### PR TITLE
User correct syntax used to pass commands to airflow dag pipeline run-tests task

### DIFF
--- a/resource/airflow_dag_pipeline.yaml
+++ b/resource/airflow_dag_pipeline.yaml
@@ -229,7 +229,7 @@ jobs:
                 start_docker
                 docker load -i image/image.tar
                 echo "Installing pytest and running tests in tests directory"
-                docker run --entrypoint "" dag/test:latest pip install pytest && pytest tests
+                docker run --entrypoint "" dag/test:latest bash -c "pip install pytest && pytest tests"
               else
                 echo 'No tests to run'
               fi


### PR DESCRIPTION
At the moment the run-tests task in the airflow dag pipeline passes 2 different commands to the docker run command. 

i.e.
docker run --entrypoint "" dag/test:latest pip install pytest && pytest tests

The first command (pip install pytest), will be run inside the docker container and the second command (pytest tests) will be run outside of the docker container.

We want to run both commands inside the docker container, so PR changes to pass both pip install pytest && pytest tests as arguments to the bash command. 

i.e.
docker run --entrypoint "" dag/test:latest bash -c "pip install pytest && pytest tests"

This will ensure that both are run inside the docker container.

I have tested this on a local copy of the Dockerfile and it worked as expected.