### PR TITLE
Fix helm stable repo

### DIFF
--- a/resource/webapp_pipeline.yaml
+++ b/resource/webapp_pipeline.yaml
@@ -128,6 +128,7 @@ resources:
     repos:
     - name: mojanalytics
       url: http://moj-analytics-helm-repo.s3-website-eu-west-1.amazonaws.com
+    stable_repo: https://charts.helm.sh/stable
 
 - name: deployment-status
   type: kubernetes


### PR DESCRIPTION
This is a fix for a helm error that started today when building apps:

```
Initializing helm...

Error: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```
As seen: https://concourse.services.alpha.mojanalytics.xyz/teams/main/pipelines/segmentation-tool/jobs/deploy/builds/20

This was due to today Google getting rid of the 'stable repo' that Helm v2 uses. See: https://github.com/hashicorp/terraform-provider-helm/issues/649 (It was deprecated in Oct).

By setting a different, valid stable_repo, helm works.